### PR TITLE
Add iter unsafe operations for BDB.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -262,7 +262,9 @@
    #:iter-put
    #:iter-rem
    #:iter-key
+   #:iter-key-unsafe
    #:iter-get
+   #:iter-get-unsafe
    #:iter-close
    
    #:dbm-num-records

--- a/src/tokyo-cabinet-bdb.lisp
+++ b/src/tokyo-cabinet-bdb.lisp
@@ -205,6 +205,16 @@
       (when (and value-ptr (not (null-pointer-p value-ptr)))
         (foreign-free value-ptr)))))
 
+(defmethod iter-get-unsafe ((iter bdb-iterator) &optional (type :string))
+  (with-foreign-object (size-ptr :int)
+    (let ((value-ptr (tcbdbcurval3 (ptr-of iter) size-ptr)))
+      (unless (null-pointer-p value-ptr)
+        (ecase type
+          (:string (foreign-string-to-lisp value-ptr :count
+                                           (mem-ref size-ptr :int)))
+          (:integer (mem-ref value-ptr :int32))
+          (:octets (copy-foreign-value value-ptr size-ptr)))))))
+
 (defmethod iter-put ((iter bdb-iterator) (value string)
                      &key (mode :current))
   (tcbdbcurput2 (ptr-of iter) value (%bdb-iter-mode mode)))
@@ -232,6 +242,16 @@
                (:octets (copy-foreign-value key-ptr size-ptr)))))
       (when (and key-ptr (not (null-pointer-p key-ptr)))
         (foreign-free key-ptr)))))
+
+(defmethod iter-key-unsafe ((iter bdb-iterator) &optional (type :string))
+  (with-foreign-object (size-ptr :int)
+    (let ((key-ptr (tcbdbcurkey3 (ptr-of iter) size-ptr)))
+      (unless (null-pointer-p key-ptr)
+        (ecase type
+          (:string (foreign-string-to-lisp key-ptr :count
+                                           (mem-ref size-ptr :int)))
+          (:integer (mem-ref key-ptr :int32))
+          (:octets (copy-foreign-value key-ptr size-ptr)))))))
 
 (defmethod dbm-num-records ((db tc-bdb))
   (tcbdbrnum (ptr-of db)))

--- a/src/tokyo-cabinet.lisp
+++ b/src/tokyo-cabinet.lisp
@@ -250,6 +250,17 @@ treated. :STRING indicates that the value should be converted to a
 Lisp string, while :OCTETS indicates that the byte vector should be
 returned."))
 
+(defgeneric iter-get-unsafe (iterator &optional type)
+  (:documentation "Returns the current value at ITERATOR. Type may be
+one of :STRING or :OCTETS , depending on how the value is to be
+treated. :STRING indicates that the value should be converted to a
+Lisp string, while :OCTETS indicates that the byte vector should be
+returned.
+Using volatile buffer thus thread-unsafe for other volatile operations
+done over this DB.")
+  (:method (iterator &optional type)
+    (iter-get iterator type)))
+
 (defgeneric iter-put (iterator value &key mode)
   (:documentation "Inserts VALUE around ITERATOR. Mode may be one
 of :CURRENT , :BEFORE or :AFTER . Only effective for B+ tree
@@ -266,6 +277,17 @@ may be one of :STRING or :OCTETS , depending on how the value is to be
 treated. :STRING indicates that the value should be converted to a
 Lisp string, while :OCTETS indicates that the byte vector should be
 returned."))
+
+(defgeneric iter-key-unsafe (iterator &optional type)
+  (:documentation "Returns current key at the ITERATOR position. Type
+may be one of :STRING or :OCTETS , depending on how the value is to be
+treated. :STRING indicates that the value should be converted to a
+Lisp string, while :OCTETS indicates that the byte vector should be
+returned.
+Using volatile buffer thus thread-unsafe for other volatile operations
+done over this DB.")
+  (:method (iterator &optional type)
+    (iter-key iterator type)))
 
 (defgeneric dbm-num-records (db)
   (:documentation "Returns the number of records in DB."))


### PR DESCRIPTION
These allow for less memory overhead when applicable.